### PR TITLE
Adjust header and publication formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,6 @@
 <body>
   <main>
   <header class="cv-header">
-    <a href="curriculum/ACacioppo_CV.pdf" class="download-btn" download>Download PDF</a>
     <h1>Andrea Cacioppo</h1>
     <p>Curriculum vitae - July 8 2025</p>
     <p>
@@ -161,6 +160,7 @@
        <img src="images/linkedin_logo.png" alt="LinkedIn" class="contact-icon" />
        <a href="https://www.linkedin.com/in/andrea-cacioppo/">LinkedIn</a>
     </p>
+    <a href="curriculum/ACacioppo_CV.pdf" class="download-btn" download>Download PDF</a>
   </header>
 
   <section id="profile">
@@ -320,7 +320,7 @@
     <h2>Publications</h2>
     <ul>
       <li>Andrea Cacioppo, Lorenzo Colantonio, Simone Bordoni, and Stefano Giagu. <b>Quantum Diffusion Models</b>. arXiv preprint arXiv:2311.15444, 2023</li>
-      <li>Lorenzo Colantonio, Andrea Cacioppo, Federico Scarpati, and Stefano Giagu. <b></b>Efficient graph coloring with neural networks: A physics-inspired approach for large graphs</b>. arXiv preprint arXiv:2408.01503, 2024.</li>
+      <li>Lorenzo Colantonio, Andrea Cacioppo, Federico Scarpati, and Stefano Giagu. <b>Efficient graph coloring with neural networks: A physics-inspired approach for large graphs</b>. arXiv preprint arXiv:2408.01503, 2024.</li>
       <li>Andrea Cacioppo, Lorenzo Colantonio, Simone Bordoni, and Stefano Giagu. <b>Quantum Diffusion Models</b>. arXiv preprint arXiv:2311.15444, 2023.</li>
       <li>Andrea Cacioppo, Janis Nötzel, and Matteo Rosati. <b>Compound Channel Capacities under Energy Constraints and Application</b>. In 2021 IEEE International Symposium on Information Theory (ISIT), pages 640–645. IEEE, 2021.</li>
       <li>Andrea Cacioppo. <b>Deep learning for the parameter estimation of tight-binding Hamiltonians</b>. Master’s thesis, Sapienza Università di Roma, Italy, 2020.</li>


### PR DESCRIPTION
## Summary
- move CV download button beneath the LinkedIn link
- fix bold markup for graph coloring publication

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f822e7e248322b7bd0d9c55915be4