### PR TITLE
Fix PDF refresh workflow

### DIFF
--- a/.github/workflows/refresh-pdf.yml
+++ b/.github/workflows/refresh-pdf.yml
@@ -4,6 +4,9 @@ on:
     - cron: '0 10 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add write permissions so refresh-pdf workflow can push updates

## Testing
- `npm ci` *(fails: Failed to set up chrome-headless-shell v138.0.7204.94)*
- `npm run pdf` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_686faedc960883229e1811648eda4b8c