### PR TITLE
Fix CV links

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,23 +187,23 @@
       <h3>Nov 2022 - pres.</h3>
       <p><b>PhD in Physics</b>, Sapienza University of Rome, Italy</p>
       <p>Topics: quantum generative models and physics-informed optimization algorithms</p>
-      <p>Group: Fisica AI&amp;QC group (<a href="https://sites.google.com/a/uniroma1.it/stefanogiagu/fisicaAI">https://sites.google.com/a/uniroma1.it/stefanogiagu/fisicaAI</a>)</p>
-      <p>Supervisors: Stefano Giagu (<a href="https://stefanogiagu.site.uniroma1.it/home">https://stefanogiagu.site.uniroma1.it/home</a>), Fabio Sciarrino (<a href="https://www.quantumlab.it/principal-investigator/">https://www.quantumlab.it/principal-investigator/</a>)</p>
+      <p>Group: <a href="https://sites.google.com/a/uniroma1.it/stefanogiagu/fisicaAI">Fisica AI&amp;QC group</a></p>
+      <p>Supervisors: <a href="https://stefanogiagu.site.uniroma1.it/home">Stefano Giagu</a>, <a href="https://www.quantumlab.it/principal-investigator/">Fabio Sciarrino</a></p>
     </article>
 
     <article>
       <h3>Nov 2020 - Nov 2021</h3>
       <p><b>PhD in Computer Engineering</b>, Technical University of Munich, Germany</p>
       <p>Topics: classical-quantum compound channels and algorithms for the automatic generation of quantum graph states</p>
-      <p>Group: Theoretical quantum system design group (<a href="https://www.ce.cit.tum.de/en/lti/tqsd/">https://www.ce.cit.tum.de/en/lti/tqsd/</a>)</p>
-      <p>Supervisors: Janis Nötzel (<a href="https://www.professoren.tum.de/en/tum-junior-fellows/n/noetzel-janis">https://www.professoren.tum.de/en/tum-junior-fellows/n/noetzel-janis</a>), Jonathan Finley (<a href="https://www.professoren.tum.de/en/finley-jonathan">https://www.professoren.tum.de/en/finley-jonathan</a>)</p>
+      <p>Group: <a href="https://www.ce.cit.tum.de/en/lti/tqsd/">Theoretical quantum system design group</a></p>
+      <p>Supervisors: <a href="https://www.professoren.tum.de/en/tum-junior-fellows/n/noetzel-janis">Janis Nötzel</a>, <a href="https://www.professoren.tum.de/en/finley-jonathan">Jonathan Finley</a></p>
     </article>
 
     <article>
       <h3>Oct 2016 - May 2020</h3>
       <p><b>M.Sc. in Physics</b>, Sapienza University of Rome, Italy</p>
       <p>Thesis: “Deep learning for the parameter estimation of tight-binding Hamiltonians”</p>
-      <p>Supervisors: Stefano Giagu (<a href="https://stefanogiagu.site.uniroma1.it/home">https://stefanogiagu.site.uniroma1.it/home</a>), Stefan Bauer (<a href="https://cifar.ca/bios/stefan-bauer/">https://cifar.ca/bios/stefan-bauer/</a>)</p>
+      <p>Supervisors: <a href="https://stefanogiagu.site.uniroma1.it/home">Stefano Giagu</a>, <a href="https://cifar.ca/bios/stefan-bauer/">Stefan Bauer</a></p>
       <p>Grade: 109/110</p>
     </article>
 
@@ -211,7 +211,7 @@
       <h3>Sept 2013 - Oct 2018</h3>
       <p><b>B.Sc. in Physics</b>, Sapienza University of Rome, Italy</p>
       <p>Thesis: “Hidden Markov model”</p>
-      <p>Supervisor : Luciano Pietronero (<a href="http://www.lucianopietronero.it">http://www.lucianopietronero.it</a>)</p>
+      <p>Supervisor : <a href="http://www.lucianopietronero.it">Luciano Pietronero</a></p>
       <p>Grade: 110/110 with honors</p>
     </article>
   </section>
@@ -227,7 +227,7 @@
 
     <article>
       <h3>Nov 2024 - Mar. 2025</h3>
-      <p><b>ML Consulting</b>, Grid + (<a href="https://www.gridplus.it">https://www.gridplus.it</a>), Rome, Italy</p>
+      <p><b>ML Consulting</b>, <a href="https://www.gridplus.it">Grid +</a>, Rome, Italy</p>
       <p>Topic: Automatic analysis of legal documents and anomaly detection</p>
     </article>
 
@@ -239,13 +239,13 @@
 
     <article>
       <h3>Sep 2023 - Nov 2023</h3>
-      <p><b>ML Consulting</b>, Hypercube SA (<a href="https://www.hypercube.eco">https://www.hypercube.eco</a>), Lugano, Switzerland</p>
+      <p><b>ML Consulting</b>, <a href="https://www.hypercube.eco">Hypercube SA</a>, Lugano, Switzerland</p>
       <p>Topic: application of ML techniques to the detection of time series anomalies</p>
     </article>
 
     <article>
       <h3>Dec 2022 - Aug 2023</h3>
-      <p><b>ML Consulting</b>, Primis Group SRL (<a href="https://www.primisgroup.com">https://www.primisgroup.com</a>), Milan, Italy</p>
+      <p><b>ML Consulting</b>, <a href="https://www.primisgroup.com">Primis Group SRL</a>, Milan, Italy</p>
       <p>Tasks: determine best ML solutions tailored to LiDAR and satellite data, design of an anomaly detection algorithm for LiDAR data (contract of Rete Ferroviaria Italiana SPA)</p>
     </article>
 


### PR DESCRIPTION
## Summary
- embed link destinations in the names/titles
- keep link text blue via existing accent styling

## Testing
- `python3 generate_cv_pdf.py` *(fails: ModuleNotFoundError: No module named 'weasyprint')*

------
https://chatgpt.com/codex/tasks/task_e_6870c5b0881c8322b200894023a9f8a9