### PR TITLE
Restrict breathing animation to CV header

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,6 @@
     main {
       max-width: 1000px;
       margin: 0 auto;
-      animation: content-breathe 8s ease-in-out infinite;
     }
 
     @keyframes content-breathe {
@@ -112,6 +111,7 @@
       justify-content: center;
       height: auto;
       box-shadow: none; /* remove default header shadow */
+      animation: content-breathe 8s ease-in-out infinite;
     }
 
     a {


### PR DESCRIPTION
## Summary
- Limit breathing animation to top CV header block so body content remains static

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m py_compile generate_cv_pdf.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6c93d30f08322947b786f348ba14d