### PR TITLE
Enhance hyperspace visuals and CTA behavior

### DIFF
--- a/hyperspace.html
+++ b/hyperspace.html
@@ -39,20 +39,6 @@
       filter: drop-shadow(0 0 20px rgba(88, 150, 255, 0.4));
     }
 
-    .instructions {
-      position: absolute;
-      bottom: 2.5rem;
-      width: 100%;
-      text-align: center;
-      font-size: 0.75rem;
-      letter-spacing: 0.35em;
-      text-transform: uppercase;
-      color: rgba(189, 205, 255, 0.55);
-      pointer-events: none;
-      user-select: none;
-      text-shadow: 0 0 12px rgba(43, 75, 255, 0.4);
-    }
-
     .back-link {
       position: absolute;
       top: 2rem;
@@ -81,13 +67,6 @@
     }
 
     @media (max-width: 600px) {
-      .instructions {
-        bottom: 1.25rem;
-        font-size: 0.65rem;
-        letter-spacing: 0.25em;
-        padding: 0 2rem;
-      }
-
       .back-link {
         top: 1.25rem;
         left: 1.25rem;
@@ -102,22 +81,12 @@
       canvas {
         display: none;
       }
-
-      .instructions::after {
-        content: 'Motion reduced';
-        display: block;
-        font-size: 0.65rem;
-        opacity: 0.6;
-        margin-top: 0.5rem;
-        letter-spacing: 0.2em;
-      }
     }
   </style>
 </head>
 <body>
   <a class="back-link" href="/" aria-label="Return to the main page">Return</a>
   <canvas id="hyperspace-canvas" role="presentation" aria-hidden="true"></canvas>
-  <p class="instructions">Move to steer · Hold to warp</p>
   <script>
     (function() {
       const canvas = document.getElementById('hyperspace-canvas');
@@ -138,6 +107,7 @@
       let lastTime = performance.now();
       const rays = [];
       const rayCount = 420;
+      const trailLength = 0.22;
       const pointer = { x: 0, y: 0, targetX: 0, targetY: 0 };
       let warp = 1;
 
@@ -154,10 +124,10 @@
         centerY = height / 2;
       }
 
-      function createRay() {
+      function createRay(initialProgress = Math.random() * trailLength) {
         return {
           angle: Math.random() * Math.PI * 2,
-          progress: Math.random(),
+          progress: initialProgress,
           speed: 0.18 + Math.random() * 0.32,
           hue: 188 + Math.random() * 90,
           pulse: 0.5 + Math.random() * 0.5
@@ -165,7 +135,7 @@
       }
 
       for (let i = 0; i < rayCount; i += 1) {
-        rays.push(createRay());
+        rays.push(createRay(Math.random()));
       }
 
       function easeOutCubic(t) {
@@ -206,29 +176,33 @@
         for (let i = 0; i < rays.length; i += 1) {
           const ray = rays[i];
           ray.progress += ray.speed * warp * delta * 0.018;
-          if (ray.progress > 1) {
-            rays[i] = createRay();
+          if (ray.progress > 1 + trailLength) {
+            rays[i] = createRay(0);
             continue;
           }
 
-          const eased = easeOutCubic(ray.progress);
-          const startRadius = eased * maxRadius * 0.1;
-          const endRadius = eased * maxRadius;
+          const clampedProgress = Math.min(ray.progress, 1);
+          const easedEnd = easeOutCubic(clampedProgress);
+          const easedStart = easeOutCubic(Math.max(0, ray.progress - trailLength));
+          const startRadius = easedStart * maxRadius;
+          const endRadius = easedEnd * maxRadius;
           const cos = Math.cos(ray.angle);
           const sin = Math.sin(ray.angle);
-          const startX = centerX + cos * startRadius * 0.35;
-          const startY = centerY + sin * startRadius * 0.35;
-          const endX = centerX + cos * (endRadius + 80 * ray.pulse);
-          const endY = centerY + sin * (endRadius + 80 * ray.pulse);
+          const startX = centerX + cos * (startRadius * 0.6);
+          const startY = centerY + sin * (startRadius * 0.6);
+          const endX = centerX + cos * (endRadius + 90 * ray.pulse);
+          const endY = centerY + sin * (endRadius + 90 * ray.pulse);
 
           const gradient = ctx.createLinearGradient(startX, startY, endX, endY);
-          gradient.addColorStop(0, `hsla(${ray.hue}, 100%, 80%, 0)`);
-          gradient.addColorStop(0.1, `hsla(${ray.hue}, 100%, 80%, ${0.15 + 0.35 * (1 - ray.progress)})`);
-          gradient.addColorStop(0.55, `hsla(${ray.hue + 10}, 100%, 65%, ${0.05 + 0.25 * (1 - eased)})`);
+          gradient.addColorStop(0, `hsla(${ray.hue}, 100%, 78%, 0)`);
+          gradient.addColorStop(0.08, `hsla(${ray.hue}, 100%, 82%, ${0.45 + 0.25 * (1 - clampedProgress)})`);
+          gradient.addColorStop(0.55, `hsla(${ray.hue + 8}, 100%, 70%, ${0.35 + 0.2 * (1 - easedEnd)})`);
+          gradient.addColorStop(0.85, `hsla(${ray.hue + 18}, 100%, 65%, 0.12)`);
           gradient.addColorStop(1, 'hsla(210, 100%, 60%, 0)');
 
           ctx.strokeStyle = gradient;
-          ctx.lineWidth = Math.max(0.6, (1 - eased) * 3.5);
+          ctx.lineCap = 'round';
+          ctx.lineWidth = Math.max(0.7, (1 - easedEnd) * 3.4);
           ctx.beginPath();
           ctx.moveTo(startX, startY);
           ctx.lineTo(endX, endY);

--- a/index.html
+++ b/index.html
@@ -72,7 +72,8 @@
       box-shadow: 0 12px 30px rgba(15, 98, 254, 0.25);
       text-transform: uppercase;
       font-size: 0.75rem;
-      transition: transform 200ms ease, box-shadow 200ms ease, background 200ms ease;
+      transition: transform 200ms ease, box-shadow 200ms ease, background 200ms ease, opacity 200ms ease;
+      will-change: transform, opacity;
     }
 
     .hyperspace-link:hover,
@@ -86,6 +87,13 @@
 
     .hyperspace-link:active {
       transform: translateY(0) scale(0.98);
+    }
+
+    .hyperspace-link.is-hidden {
+      opacity: 0;
+      pointer-events: none;
+      transform: translateY(-10px) scale(0.96);
+      box-shadow: 0 4px 16px rgba(15, 98, 254, 0.18);
     }
 
     main {
@@ -486,5 +494,42 @@
   </section>
 
 </main>
+  <script>
+    (function() {
+      const hyperspaceLink = document.querySelector('.hyperspace-link');
+      if (!hyperspaceLink) {
+        return;
+      }
+
+      const hiddenClass = 'is-hidden';
+      const threshold = 16;
+      let lastScrollY = window.scrollY;
+
+      function showLink() {
+        hyperspaceLink.classList.remove(hiddenClass);
+      }
+
+      function hideLink() {
+        hyperspaceLink.classList.add(hiddenClass);
+      }
+
+      function handleScroll() {
+        const currentY = window.scrollY;
+        if (currentY <= threshold) {
+          showLink();
+        } else if (currentY > lastScrollY + 2) {
+          hideLink();
+        } else if (currentY < lastScrollY - 2) {
+          showLink();
+        }
+        lastScrollY = currentY;
+      }
+
+      window.addEventListener('scroll', handleScroll, { passive: true });
+      if (window.scrollY > threshold) {
+        hideLink();
+      }
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove the instructional overlay from the hyperspace scene
- reshape hyperspace beams to render with a defined head and tail for clearer motion
- keep the hyperspace button fixed to the top-right of the main page and hide it while scrolling down

## Testing
- No automated tests were run (static HTML updates)


------
https://chatgpt.com/codex/tasks/task_e_68d3c8d417408322828a01d26793020f