### PR TITLE
Add dedicated teaching section to CV

### DIFF
--- a/index.html
+++ b/index.html
@@ -385,12 +385,6 @@
     </article>
 
     <article>
-      <h3>Jan 2022 - Nov 2024</h3>
-      <p><b>Tutoring</b>, Individual clients, Italy</p>
-      <p>Topics: mathematics, physics and computer science for university students</p>
-    </article>
-
-    <article>
       <h3>Sep 2023 - Nov 2023</h3>
       <p><b>Machine Learning Consulting</b>, <a href="https://www.hypercube.eco">Hypercube SA</a>, Lugano, Switzerland</p>
       <p>Topic: application of Machine Learning techniques to the detection of time series anomalies</p>
@@ -403,15 +397,31 @@
     </article>
 
     <article>
-      <h3>Nov 2020 - Nov 2021</h3>
-      <p><b>Tutoring</b>, Technical University of Munich, Germany</p>
-      <p>Task: assisting students of the "Quantum networking" class</p>
-    </article>
-
-    <article>
       <h3>Sep 2019 - Oct 2020</h3>
       <p><b>Research Internship</b>, Max Planck Institute for Intelligent Systems, Tübingen, Germany</p>
       <p>Topics: Deep learning for estimating tight-binding Hamiltonians, quantum machine learning models and their connection with kernel methods</p>
+    </article>
+  </section>
+
+  <section id="teaching">
+    <h2>Teaching</h2>
+
+    <article>
+      <h3>Sep 2025 - Present</h3>
+      <p><b>Tutoring</b>, Sapienza University of Rome, Italy</p>
+      <p>Task: assisting students of the "Foundations of Programming with Laboratory (Mathematical Sciences for Artificial Intelligence)" course</p>
+    </article>
+
+    <article>
+      <h3>Jan 2022 - Nov 2024</h3>
+      <p><b>Tutoring</b>, Individual clients, Italy</p>
+      <p>Topics: mathematics, physics and computer science for university students</p>
+    </article>
+
+    <article>
+      <h3>Nov 2020 - Nov 2021</h3>
+      <p><b>Tutoring</b>, Technical University of Munich, Germany</p>
+      <p>Task: assisting students of the "Quantum networking" class</p>
     </article>
   </section>
 


### PR DESCRIPTION
## Summary
- add a new Teaching section to the CV after the work experience entries
- move the existing tutoring roles out of Work experience into the new Teaching section
- document a new tutoring position at Sapienza University of Rome beginning September 2025

## Testing
- no automated tests were run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68dd3cc0d0a883229404d3ee18516f61