### PR TITLE
Adjust hard truths call-to-action for mobile screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,6 +213,25 @@
         margin-bottom: 0.5rem !important;
       }
     }
+
+    @media (max-width: 600px) {
+      .hard-truths-link {
+        top: auto;
+        right: 1rem;
+        bottom: 1.25rem;
+        left: 1rem;
+        padding: 0.75rem 1.5rem;
+        text-align: center;
+        font-size: 0.82rem;
+        letter-spacing: 0.08em;
+        box-shadow: 0 16px 30px rgba(15, 98, 254, 0.28);
+      }
+
+      .hard-truths-link.is-hidden {
+        transform: translateY(12px) scale(0.96);
+        box-shadow: 0 8px 24px rgba(15, 98, 254, 0.22);
+      }
+    }
   </style>
 
   <!-- JSON-LD: Enriched schema for AI/ATS parsing -->


### PR DESCRIPTION
## Summary
- reposition the hard truths floating button on narrow viewports so it sits above the content instead of behind the hero image
- widen the touch target and tweak typography and shadows on mobile for better legibility
- ensure the hide animation respects the new bottom placement on phones

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff9d5321e483229fc4eedb6bc4f63b