### PR TITLE
feat: add red pill entrypoint and matrix backdrop

### DIFF
--- a/hard-truths.html
+++ b/hard-truths.html
@@ -42,6 +42,17 @@
       overflow: hidden;
     }
 
+    .matrix-canvas {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      mix-blend-mode: screen;
+      opacity: 0.35;
+      z-index: 1;
+    }
+
     .stars,
     .stars::after {
       position: absolute;
@@ -174,6 +185,7 @@
       filter: blur(0.4px);
       opacity: 0.45;
       transform: translate(-50%, -50%);
+      z-index: 0;
     }
 
     .stars::after {
@@ -189,6 +201,7 @@
       filter: blur(60px);
       opacity: 0.7;
       animation: pulse 12s ease-in-out infinite;
+      z-index: 2;
     }
 
     @keyframes pulse {
@@ -198,6 +211,7 @@
 
     .message {
       position: relative;
+      z-index: 3;
       text-align: center;
       max-width: min(80vw, 34rem);
       font-size: clamp(1.6rem, 3vw, 2.6rem);
@@ -286,10 +300,91 @@
   <a class="back-link" href="/" aria-label="return to the main page">home</a>
   <div class="scene">
     <div class="stars" aria-hidden="true"></div>
+    <canvas class="matrix-canvas" aria-hidden="true"></canvas>
     <div class="haze" aria-hidden="true"></div>
     <p class="message">
       Advertising is the most toxic pollutant in the world
     </p>
   </div>
+
+  <script>
+    const canvas = document.querySelector('.matrix-canvas');
+    const ctx = canvas.getContext('2d');
+    const characters = '01';
+    const fontSize = 16;
+    let width = 0;
+    let height = 0;
+    let columns = 0;
+    let drops = [];
+    let animationHandle = null;
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+    function resizeCanvas() {
+      const dpr = window.devicePixelRatio || 1;
+      const viewportWidth = window.innerWidth;
+      const viewportHeight = window.innerHeight;
+      canvas.width = viewportWidth * dpr;
+      canvas.height = viewportHeight * dpr;
+      canvas.style.width = viewportWidth + 'px';
+      canvas.style.height = viewportHeight + 'px';
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.scale(dpr, dpr);
+      width = viewportWidth;
+      height = viewportHeight;
+      columns = Math.ceil(width / fontSize);
+      drops = Array(columns).fill(0);
+    }
+
+    function draw() {
+      ctx.fillStyle = 'rgba(0, 0, 0, 0.1)';
+      ctx.fillRect(0, 0, width, height);
+
+      ctx.fillStyle = 'rgba(0, 255, 80, 0.65)';
+      ctx.font = fontSize + "px 'Courier New', monospace";
+
+      for (let i = 0; i < columns; i++) {
+        const text = characters.charAt(Math.floor(Math.random() * characters.length));
+        const x = i * fontSize;
+        const y = drops[i] * fontSize;
+
+        ctx.fillText(text, x, y);
+
+        if (y > height && Math.random() > 0.975) {
+          drops[i] = 0;
+        } else {
+          drops[i] += 0.9;
+        }
+      }
+
+      animationHandle = requestAnimationFrame(draw);
+    }
+
+    function startMatrix() {
+      if (animationHandle) {
+        cancelAnimationFrame(animationHandle);
+        animationHandle = null;
+      }
+
+      if (prefersReducedMotion.matches) {
+        ctx.clearRect(0, 0, width, height);
+        return;
+      }
+
+      animationHandle = requestAnimationFrame(draw);
+    }
+
+    window.addEventListener('resize', () => {
+      resizeCanvas();
+      startMatrix();
+    });
+    if (typeof prefersReducedMotion.addEventListener === 'function') {
+      prefersReducedMotion.addEventListener('change', startMatrix);
+    } else if (typeof prefersReducedMotion.addListener === 'function') {
+      prefersReducedMotion.addListener(startMatrix);
+    }
+
+    resizeCanvas();
+    startMatrix();
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -64,12 +64,12 @@
       right: 1.5rem;
       z-index: 1000;
       padding: 0.6rem 1.25rem;
-      background: linear-gradient(135deg, rgba(15, 98, 254, 0.95), rgba(15, 98, 254, 0.6));
+      background: linear-gradient(135deg, rgba(185, 32, 32, 0.95), rgba(255, 94, 58, 0.8));
       color: #fff;
       font-weight: 600;
       letter-spacing: 0.05em;
       border-radius: 999px;
-      box-shadow: 0 12px 30px rgba(15, 98, 254, 0.25);
+      box-shadow: 0 12px 30px rgba(210, 40, 40, 0.25);
       text-transform: uppercase;
       font-size: 0.75rem;
       transition: transform 200ms ease, box-shadow 200ms ease, background 200ms ease, opacity 200ms ease;
@@ -78,8 +78,8 @@
 
     .hard-truths-link:hover,
     .hard-truths-link:focus-visible {
-      background: linear-gradient(135deg, rgba(80, 140, 255, 1), rgba(15, 98, 254, 0.8));
-      box-shadow: 0 16px 40px rgba(15, 98, 254, 0.35);
+      background: linear-gradient(135deg, rgba(220, 30, 30, 1), rgba(255, 120, 85, 0.95));
+      box-shadow: 0 16px 40px rgba(220, 50, 50, 0.35);
       transform: translateY(-2px) scale(1.02);
       text-decoration: none;
       outline: none;
@@ -93,7 +93,7 @@
       opacity: 0;
       pointer-events: none;
       transform: translateY(-10px) scale(0.96);
-      box-shadow: 0 4px 16px rgba(15, 98, 254, 0.18);
+      box-shadow: 0 4px 16px rgba(200, 35, 35, 0.2);
     }
 
     main {
@@ -224,12 +224,12 @@
         text-align: center;
         font-size: 0.82rem;
         letter-spacing: 0.08em;
-        box-shadow: 0 16px 30px rgba(15, 98, 254, 0.28);
+        box-shadow: 0 16px 30px rgba(220, 50, 50, 0.32);
       }
 
       .hard-truths-link.is-hidden {
         transform: translateY(12px) scale(0.96);
-        box-shadow: 0 8px 24px rgba(15, 98, 254, 0.22);
+        box-shadow: 0 8px 24px rgba(200, 35, 35, 0.26);
       }
     }
   </style>
@@ -333,7 +333,7 @@
   </script>
 </head>
 <body>
-  <a class="hard-truths-link" href="/hard-truths.html" aria-label="open the hard truths experience">hard truths</a>
+  <a class="hard-truths-link" href="/hard-truths.html" aria-label="open the red pill experience">red pill</a>
   <main>
   <header class="cv-header">
     <img src="images/foto_profilo.jpeg" alt="Profile picture" class="profile-pic" />


### PR DESCRIPTION
## Summary
- restyle the floating CTA to present a red pill theme and label
- add an animated green binary canvas overlay to the hard truths page for a matrix ambience
- ensure the animation respects reduced-motion preferences while keeping existing layering effects intact

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_69034813587c8322a0e93000fa1bc50a